### PR TITLE
Add Otomo damages in total damages

### DIFF
--- a/mhrise-coavins-dps.lua
+++ b/mhrise-coavins-dps.lua
@@ -847,6 +847,7 @@ function calculateTotalsForReportItem(item)
 	item.totalPhysical = 0.0;
 	item.totalElemental = 0.0;
 	item.totalCondition = 0.0;
+	item.totalOtomo = 0.0;
 
 	-- get totals from counters
 	for type,counter in pairs(item.counters) do


### PR DESCRIPTION
Hey,
the commit 95a8df0ad29688ac007bae2d77615881a0cbd973 seems to contain a bug where Partner damages are displayed out of the normal bar size : 
![bug](https://user-images.githubusercontent.com/32908972/150959216-0b648d32-1b7d-46ae-a7da-a6d2b9ac765d.png)

The line 858 might be the issue here ? :
https://github.com/coavins/mhrise-coavins-dps/blob/95a8df0ad29688ac007bae2d77615881a0cbd973/mhrise-coavins-dps.lua#L858

Changing it to
```lua
item.total = item.total + item.totalOtomo;
```
Seems to fix this (at least visually, it works :3)